### PR TITLE
Move Fabric Configuration Directory from config/ to config/NuVotifier

### DIFF
--- a/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
+++ b/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
@@ -143,18 +143,18 @@ public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteLis
     }
 
     /**
-     * Onetime migration of the config from config/rsa and config/nuvotifier.yml to config/nuvotifier/
+     * Onetime migration of the config from config/rsa and config/nuvotifier.yml to config/NuVotifier/
      */
     private boolean migrateConfig() {
         File configFile = FabricLoader.getInstance().getConfigDir().resolve("nuvotifier.yml").toFile();
         File rsaDir = FabricLoader.getInstance().getConfigDir().resolve("rsa").toFile();
         try {
             if (configFile.exists()) {
-                LOGGER.info("Migrating config from config/nuvotifier.yml to config/nuvotifier/nuvotifier.yml");
+                LOGGER.info("Migrating config from config/nuvotifier.yml to config/NuVotifier/nuvotifier.yml");
                 configFile.renameTo(new File(configDir, "nuvotifier.yml"));
             }
             if (rsaDir.exists()) {
-                LOGGER.info("Migrating RSA keys from config/rsa to config/nuvotifier/rsa");
+                LOGGER.info("Migrating RSA keys from config/rsa to config/NuVotifier/rsa");
                 rsaDir.renameTo(new File(configDir, "rsa"));
             }
         } catch (Exception e) {

--- a/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
+++ b/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
@@ -16,6 +16,7 @@ import com.vexsoftware.votifier.platform.scheduler.ScheduledExecutorServiceVotif
 import com.vexsoftware.votifier.platform.scheduler.VotifierScheduler;
 import com.vexsoftware.votifier.support.forwarding.ForwardedVoteListener;
 import com.vexsoftware.votifier.util.KeyCreator;
+import java.io.IOException;
 import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -50,11 +51,17 @@ public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteLis
         /*
          * Create NuVotifier Config directory if it does not exist
          */
-        if (!configDir.exists()) {
-            if (!configDir.mkdir()) {
-                throw new RuntimeException("Unable to create the NuVotifier config folder " + configDir);
+        try {
+            if (!configDir.exists()) {
+                if (!configDir.mkdir()) {
+                    throw new RuntimeException("Unable to create the NuVotifier config folder " + configDir);
+                }
             }
+        } catch (RuntimeException ex) {
+            LOGGER.error("Unable to create the NuVotifier config folder", ex);
+            return false;
         }
+
 
         /*
          * Create RSA directory and keys if it does not exist; otherwise, read

--- a/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
+++ b/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
@@ -39,13 +39,22 @@ public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteLis
 
     private SLF4JLogger loggerAdapter;
 
-    public File configDir = FabricLoader.getInstance().getConfigDir().toFile();
+    public File configDir = FabricLoader.getInstance().getConfigDir().resolve("NuVotifier").toFile();
 
     private VotifierScheduler scheduler;
 
     private boolean loadAndBind() {
         // Load configuration.
         ConfigLoader.loadConfig(this);
+
+        /*
+         * Create NuVotifier Config directory if it does not exist
+         */
+        if (!configDir.exists()) {
+            if (!configDir.mkdir()) {
+                throw new RuntimeException("Unable to create the NuVotifier config folder " + configDir);
+            }
+        }
 
         /*
          * Create RSA directory and keys if it does not exist; otherwise, read

--- a/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
+++ b/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
@@ -16,7 +16,6 @@ import com.vexsoftware.votifier.platform.scheduler.ScheduledExecutorServiceVotif
 import com.vexsoftware.votifier.platform.scheduler.VotifierScheduler;
 import com.vexsoftware.votifier.support.forwarding.ForwardedVoteListener;
 import com.vexsoftware.votifier.util.KeyCreator;
-import java.io.IOException;
 import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;

--- a/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
+++ b/src/main/java/com/vexsoftware/votifier/fabric/NuVotifier.java
@@ -16,6 +16,12 @@ import com.vexsoftware.votifier.platform.scheduler.ScheduledExecutorServiceVotif
 import com.vexsoftware.votifier.platform.scheduler.VotifierScheduler;
 import com.vexsoftware.votifier.support.forwarding.ForwardedVoteListener;
 import com.vexsoftware.votifier.util.KeyCreator;
+import java.io.File;
+import java.security.Key;
+import java.security.KeyPair;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
 import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -23,13 +29,6 @@ import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.MinecraftServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.security.Key;
-import java.security.KeyPair;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Executors;
 
 public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteListener, DedicatedServerModInitializer {
 
@@ -44,9 +43,6 @@ public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteLis
     private VotifierScheduler scheduler;
 
     private boolean loadAndBind() {
-        // Load configuration.
-        ConfigLoader.loadConfig(this);
-
         /*
          * Create NuVotifier Config directory if it does not exist
          */
@@ -61,6 +57,16 @@ public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteLis
             return false;
         }
 
+        // Check if there is an old config
+        if (FabricLoader.getInstance().getConfigDir().resolve("nuvotifier.yml").toFile().exists()) {
+            // Migrate config
+            if (!migrateConfig()) {
+                return false;
+            }
+        }
+
+        // Load configuration.
+        ConfigLoader.loadConfig(this);
 
         /*
          * Create RSA directory and keys if it does not exist; otherwise, read
@@ -133,6 +139,29 @@ public class NuVotifier implements VoteHandler, VotifierPlugin, ForwardedVoteLis
                 LOGGER.error("No vote forwarding method '" + method + "' known. Defaulting to noop implementation.");
             }
         }
+        return true;
+    }
+
+    /**
+     * Onetime migration of the config from config/rsa and config/nuvotifier.yml to config/nuvotifier/
+     */
+    private boolean migrateConfig() {
+        File configFile = FabricLoader.getInstance().getConfigDir().resolve("nuvotifier.yml").toFile();
+        File rsaDir = FabricLoader.getInstance().getConfigDir().resolve("rsa").toFile();
+        try {
+            if (configFile.exists()) {
+                LOGGER.info("Migrating config from config/nuvotifier.yml to config/nuvotifier/nuvotifier.yml");
+                configFile.renameTo(new File(configDir, "nuvotifier.yml"));
+            }
+            if (rsaDir.exists()) {
+                LOGGER.info("Migrating RSA keys from config/rsa to config/nuvotifier/rsa");
+                rsaDir.renameTo(new File(configDir, "rsa"));
+            }
+        } catch (Exception e) {
+            LOGGER.error("Error migrating config!", e);
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Before this patch the NuVotifier dumped its configuration straight into the config/ folder, resulting in a cluttered folder and inconsistent behaviour across platforms.
<img width="435" height="198" alt="image" src="https://github.com/user-attachments/assets/fa584800-06f4-401e-aa37-40796665132b" />

With this PR the config directory is moved into a subdirectory of the config folder.
<img width="417" height="172" alt="image" src="https://github.com/user-attachments/assets/0553b2b9-35b4-46e3-b0c3-e8e3cb923dae" />
